### PR TITLE
Release

### DIFF
--- a/src/init-service.js
+++ b/src/init-service.js
@@ -18,6 +18,8 @@ if (gitUrl != "") {
             console.log("Cloned repo " + gitUrl + " branch " + gitBranch + " path " + gitTemplatePath);
         })
         .catch(function (err) {
+            console.log('Unable to clone repo: ');
+            console.log(err);
             throw new Error('Unable to clone repo: ' + err);
         });
 }

--- a/src/lib/git-filesystem/git-filesystem.js
+++ b/src/lib/git-filesystem/git-filesystem.js
@@ -69,7 +69,7 @@ var getTemplatesFromRepo = function (gitUrl, gitBranch, templatePath) {
             .catch(function(err) {
                 reject(err);
             });
-        });
+    });
 };
 
 var getRepository = function () {

--- a/src/routes.js
+++ b/src/routes.js
@@ -26,6 +26,15 @@ var templatePath = process.env.TEMPLATE_GIT_PATH || "";
 var gitBranch = process.env.TEMPLATE_GIT_BRANCH || "";
 
 module.exports = function (app) {
+
+    // Make sure init-service succeeded and we have service-templates
+    fs.access(constants.TEMPLATE_FILES_LOCATION, function(err) {
+        if (err) {
+            throw new Error("service-templates directory does not exists " + err);
+        } 
+    });
+
+
     const workerPool = new WorkerPool('./src/lib/workers/worker.js', require('os').cpus().length);
     let templateCache = new fileSystemCache(constants.TEMPLATE_FILES_LOCATION);
     templateCache.init();
@@ -154,7 +163,8 @@ module.exports = function (app) {
     app.get('/api/sample-data', function (req, res) {
         messageCache.keys()
             .then((files) => res.json({ messages: files.map(f => { return { messageName: f }; }) }))
-            .catch(() => {
+            .catch((err) => {
+                console.log("Sample-data error: " + err);
                 res.status(404);
                 res.json(errorMessage(errorCodes.NotFound, 'Unable to access sample data location'));
             });
@@ -192,7 +202,8 @@ module.exports = function (app) {
     app.get('/api/sample-data/:file(*)', function (req, res) {
         messageCache.get(req.params.file)
             .then((content) => res.end(content.toString()))
-            .catch(() => {
+            .catch((err) => {
+                console.log(err);
                 res.status(404);
                 res.json(errorMessage(errorCodes.NotFound, "Sample data not found"));
             });
@@ -498,7 +509,8 @@ module.exports = function (app) {
     app.get('/api/templates', function (req, res) {
         templateCache.keys()
             .then((files) => res.json({ templates: files.map(f => { return { templateName: f }; }) }))
-            .catch(() => {
+            .catch((err) => {
+                console.log("Templates error: " + err);
                 res.status(404);
                 res.json(errorMessage(errorCodes.NotFound, 'Unable to access templates location'));
             });
@@ -538,7 +550,8 @@ module.exports = function (app) {
     app.get('/api/templates/:file(*)', function (req, res) {
         templateCache.get(req.params.file)
             .then((content) => res.end(content.toString()))
-            .catch(() => {
+            .catch((err) => {
+                console.log("Templates/file error: " + err);
                 res.status(404);
                 res.json(errorMessage(errorCodes.NotFound, "Template not found"));
             });
@@ -592,7 +605,8 @@ module.exports = function (app) {
                         res.status(exists ? 200 : 201);
                         res.end();
                     })
-                    .catch(() => {
+                    .catch((err) => {
+                        console.log("Templates/file error: " + err);
                         res.status(403);
                         res.json(errorMessage(errorCodes.WriteError, 'Unable to write template ' + req.params.file));
                     });
@@ -635,7 +649,8 @@ module.exports = function (app) {
                 res.status(204);
                 res.end();
             })
-            .catch(() => {
+            .catch((err) => {
+                console.log("Templates/file error: " + err);
                 res.status(404);
                 res.json(errorMessage(errorCodes.NotFound, 'Unable to find a template with name ' + req.params.file + ' to delete.'));
             });


### PR DESCRIPTION
Following fixes
- Do not start FHIR converter if service-templates folder is missing (contains crucial conversion templates). This should trigger restart by k8s(?)
- Print error to console if it happens when cloning templates from github repo to service-templates
- Print error to console if error is returned to client via API endpoints

Note: Requires redeployment