### PR TITLE
add handling for empty SCH-7

### DIFF
--- a/src/templates/hl7v2/Resources/Appointment.hbs
+++ b/src/templates/hl7v2/Resources/Appointment.hbs
@@ -7,8 +7,13 @@
         "reasonCode": [
             {
                 "coding": [{
+                {{#if SCH-7}}
                 {{! Remove leading&trailing spaces. Replace multiple spaces in the middle with one in the}}
                     "code": "{{replace (replace SCH-7 '^[ \s]+|[ \s]+$' '') '\s{2,}' ' '}}"
+                {{/if}}
+                {{#unless SCH-7}}
+                    "code": ""
+                {{/unless}}
                 }]
             }
             ]

--- a/src/templates/hl7v2/Resources/Appointment.hbs
+++ b/src/templates/hl7v2/Resources/Appointment.hbs
@@ -10,10 +10,9 @@
                 {{#if SCH-7}}
                 {{! Remove leading&trailing spaces. Replace multiple spaces in the middle with one in the}}
                     "code": "{{replace (replace SCH-7 '^[ \s]+|[ \s]+$' '') '\s{2,}' ' '}}"
-                {{/if}}
-                {{#unless SCH-7}}
+                {{else}}
                     "code": ""
-                {{/unless}}
+                {{/if}}
                 }]
             }
             ]

--- a/src/templates/hl7v2/Resources/Appointment.hbs
+++ b/src/templates/hl7v2/Resources/Appointment.hbs
@@ -4,18 +4,16 @@
         "identifier":[
             { {{>DataType/EIIdentifier.hbs EI=SCH-2}} }
         ],
+        {{#if SCH-7}}
         "reasonCode": [
             {
                 "coding": [{
-                {{#if SCH-7}}
                 {{! Remove leading&trailing spaces. Replace multiple spaces in the middle with one in the}}
                     "code": "{{replace (replace SCH-7 '^[ \s]+|[ \s]+$' '') '\s{2,}' ' '}}"
-                {{else}}
-                    "code": ""
-                {{/if}}
                 }]
             }
             ]
+        {{/if}}
         "status": {{>CodeSystem/AppointmentStatus.hbs STATUS=(toLower SCH-25)}},
         "minutesDuration": {{SCH-9}},
         "comment": "{{NTE-3}}"


### PR DESCRIPTION
## Description

This PR adds handling for empty SCH-7 fields in HL7 v2 Appointment messages. Otherwise the FHIR converter returns "Bad Request" because the `replace` helper is not able to treat null.

## Related issues

Addresses KAIKU-11140.

## Testing

Tested changes locally with FHIR converter. Without the change, the original error is reproduced locally. With the change, the error does no longer occur.
