### PR TITLE
KAIKU-11259 Add Trivy Docker scanner

### DIFF
--- a/.github/workflows/netmediDockerPush.yml
+++ b/.github/workflows/netmediDockerPush.yml
@@ -7,74 +7,67 @@ on:
       - handlebars
       - handlebars-stable
 
-
 env:
   IMAGE_NAME: fhir-converter
 
 jobs:
-  docker-acr-images:
+  push_to_registry:
+    name: Publish Docker image
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        registry: ["globalkaikuacr", "tstglobalkaikuacr"]
+        registry:
+          [
+            "globalkaikuacr.azurecr.io",
+            "tstglobalkaikuacr.azurecr.io",
+            "eu.gcr.io/stevedore-production-42a0d764",
+          ]
         include:
-          - registry: "globalkaikuacr"
-            acr_secret_username: "PROD_ACR_PUSH_USERNAME"
-            acr_secret_password: "PROD_ACR_PUSH_PASSWORD"
-          - registry: "tstglobalkaikuacr"
-            acr_secret_username: "TST_ACR_PUSH_USERNAME"
-            acr_secret_password: "TST_ACR_PUSH_PASSWORD"
+          - registry: globalkaikuacr.azurecr.io
+            username: PROD_ACR_PUSH_USERNAME
+            password: PROD_ACR_PUSH_PASSWORD
+          - registry: tstglobalkaikuacr.azurecr.io
+            username: TST_ACR_PUSH_USERNAME
+            password: TST_ACR_PUSH_PASSWORD
+          - registry: eu.gcr.io/stevedore-production-42a0d764
+            username: GCR_USERNAME
+            password: GCR_JSON_KEY
     steps:
-      - name: Checkout
+      - name: Check out the repo
         uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      # Connect to Azure Container Registry (ACR)
-      - uses: azure/docker-login@v1
+      - name: Check out the docker-action repository
+        uses: actions/checkout@v3
         with:
-          login-server: ${{ matrix.registry }}.azurecr.io
-          username: ${{ secrets[matrix.acr_secret_username] }}
-          password: ${{ secrets[matrix.acr_secret_password] }}
-      - name: Build and push
-        if: ${{ github.ref == 'refs/heads/handlebars' }}
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ matrix.registry }}.azurecr.io/${{ env.IMAGE_NAME }}:dev
-      - name: Build and push
-        if: ${{ github.ref == 'refs/heads/handlebars-stable' }}
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: ${{ matrix.registry }}.azurecr.io/${{ env.IMAGE_NAME }}:latest
+          repository: netMedi/docker-action
+          token: ${{ secrets.GIT_ACTION_NETMEDI_INTEGRATION_PAT }}
+          path: docker-action
 
-  docker-gcp-image:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      # Connect to GCP container registry
-      - name: Login to GCR
-        uses: docker/login-action@v2
-        with:
-          registry: eu.gcr.io
-          username: _json_key
-          password: ${{ secrets.GCR_JSON_KEY }}
-      - name: Build and push
+      - name: Build & Push Docker image
         if: ${{ github.ref == 'refs/heads/handlebars' }}
-        uses: docker/build-push-action@v2
         with:
-          context: .
-          push: true
-          tags: eu.gcr.io/stevedore-production-42a0d764/${{ env.IMAGE_NAME }}:dev
-      - name: Build and push
+          registry: ${{ matrix.registry }}
+          image: ${{ env.IMAGE_NAME }}
+          tag: dev
+          username: ${{ secrets[matrix.username] }}
+          password: ${{ secrets[matrix.password] }}
+          trivy_exit_code: "0"
+          trivy_format: "table"
+          trivy_vuln_type: "os,library"
+          trivy_severity: "CRITICAL,HIGH"
+          trivy_ignore_unfixed: true
+        uses: ./docker-action
+
+      - name: Build & Push Docker image
         if: ${{ github.ref == 'refs/heads/handlebars-stable' }}
-        uses: docker/build-push-action@v2
         with:
-          context: .
-          push: true
-          tags: eu.gcr.io/stevedore-production-42a0d764/${{ env.IMAGE_NAME }}:latest
+          registry: ${{ matrix.registry }}
+          image: ${{ env.IMAGE_NAME }}
+          tag: latest
+          username: ${{ secrets[matrix.username] }}
+          password: ${{ secrets[matrix.password] }}
+          trivy_exit_code: "0"
+          trivy_format: "table"
+          trivy_vuln_type: "os,library"
+          trivy_severity: "CRITICAL,HIGH"
+          trivy_ignore_unfixed: true
+        uses: ./docker-action


### PR DESCRIPTION
## Description

This change will update the existing GitHub Action to run the Trivy vulnerability scanner for containers and other artifacts. Unfortunately, there's no easy way to get the output of the result since we can't upload the sarif file to GitHub without GitHub Code Scanning enabled (license change needed).
