### PR TITLE
Use cert-manager API v1

### DIFF
--- a/charts/fhir-converter/templates/issuer.yaml
+++ b/charts/fhir-converter/templates/issuer.yaml
@@ -1,5 +1,5 @@
 {{- if and (.Values.fhir.certIssuer.enabled) (eq "gcp" .Values.ingress.cloud) -}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: letsencrypt-prod
@@ -15,7 +15,7 @@ spec:
           ingress:
             class: nginx
 {{- else if and (.Values.fhir.certIssuer.enabled) (eq "azure" .Values.ingress.cloud) -}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: letsencrypt-prod


### PR DESCRIPTION
Use cert-manager API v1 instead of deprecated v1alpha2

## Related issues

Error: UPGRADE FAILED: resource mapping not found for name: "letsencrypt-prod" namespace: "fhir-converter" from "": no matches for kind "Issuer" in version "cert-manager.io/v1alpha2"


## Testing

N/A
